### PR TITLE
Fix error when the text input for email doesn't exist on signin form

### DIFF
--- a/lib/amazon_auth/extensions/session_extension.rb
+++ b/lib/amazon_auth/extensions/session_extension.rb
@@ -55,7 +55,7 @@ module AmazonAuth
         log "signInSubmit button not found in this page"
         return false
       end
-      session.fill_in 'ap_email', with: login if session.first('#ap_email').value.blank?
+      session.fill_in 'ap_email', with: login if session.first('#ap_email') && session.first('#ap_email').value.blank?
       session.fill_in 'ap_password', with: password
       session.first('#signInSubmit').click
       log "Clicked signInSubmit"


### PR DESCRIPTION
Amazon changed the sign in form to have label instead of text field when the session is kept with cookie.

<img width="409" alt="amazon_signin_email2018-01-22" src="https://user-images.githubusercontent.com/275284/35224349-0dcb4ecc-ffc8-11e7-8d9b-9ec514d3584c.png">
