### PR TITLE
Fix first to work with capybara 3.2

### DIFF
--- a/lib/amazon_auth/extensions/session_extension.rb
+++ b/lib/amazon_auth/extensions/session_extension.rb
@@ -12,7 +12,7 @@ module AmazonAuth
 
     def wait_for_selector(selector, options = {})
       options.fetch(:wait_time, 3).times do
-        if session.first(selector)
+        if session.first(selector, minimum: 0)
           break
         else
           sleep(1)
@@ -56,7 +56,7 @@ module AmazonAuth
         log "signInSubmit button not found in this page"
         return false
       end
-      session.fill_in 'ap_email', with: login if session.first('#ap_email') && session.first('#ap_email').value.blank?
+      session.fill_in 'ap_email', with: login if session.first('#ap_email', minimum: 0) && session.first('#ap_email').value.blank?
       session.fill_in 'ap_password', with: password
       session.first('#signInSubmit').click
       log "Clicked signInSubmit"


### PR DESCRIPTION
Probably `first` has changed in capybara 3
https://github.com/teamcapybara/capybara/commit/d873b83b2aeba0c479bc589a8542072c7b5d69eb#diff-e0a7e0b5db6bbb0355a03b1e6ee1e3b0
