### PR TITLE
Fix signin

### DIFF
--- a/lib/amazon_auth/extensions/session_extension.rb
+++ b/lib/amazon_auth/extensions/session_extension.rb
@@ -57,7 +57,12 @@ module AmazonAuth
 
       debug "Begin submit_signin_form"
       unless session.has_selector?('#signInSubmit')
-        if session.has_selector?('input#continue') && session.has_selector?('input#ap_email')
+        if session.has_selector?('#continue input.a-button-input') && session.has_selector?('input#ap_email_login')
+          log "Found a form which asks only email (v2)"
+          session.fill_in 'ap_email_login', with: login
+          session.first('#continue input.a-button-input').click
+        # Maybe the following form is deprecated
+        elsif session.has_selector?('input#continue') && session.has_selector?('input#ap_email')
           log "Found a form which asks only email"
           session.fill_in 'ap_email', with: login
           session.first('input#continue').click


### PR DESCRIPTION
HTML抜粋

```html
<div class="a-section">
   <input type="hidden" name="email" value="" id="ap_email">
   <input type="text" value="" id="ap-credential-autofill-hint" autocomplete="email" name="email" spellcheck="false" class="a-input-text hide" data-claim="">
   <div class="a-section a-spacing-large">
      <div class="a-row">
         <div class="a-column a-span5">
            <label for="ap_password" class="a-form-label">
            パスワード
            </label>
         </div>
         <div class="a-column a-span7 a-text-right a-span-last">
            <a id="auth-fpp-link-bottom" class="a-link-normal" href="https://www.amazon.co.jp/ap/forgotpassword?openid.pape.max_auth_age=0&">
            パスワードを忘れた方
            </a>
         </div>
      </div>
      <input type="password" maxlength="1024" id="ap_password" autocomplete="current-password" name="password" spellcheck="false" class="a-input-text a-span12 auth-autofocus auth-required-field" aria-required="true">
      <div id="auth-password-missing-alert" class="a-box a-alert-inline a-alert-inline-error auth-inlined-error-message a-spacing-top-base" role="alert">
         <div class="a-box-inner a-alert-container">
            <i class="a-icon a-icon-alert"></i>
            <div class="a-alert-content">
               パスワードは6文字以上の半角英数字で入力してください
            </div>
         </div>
      </div>
   </div>
   <div class="a-section">
      <span id="auth-signin-button" class="a-button a-button-span12 a-button-primary auth-disable-button-on-submit"><span class="a-button-inner"><input id="signInSubmit" class="a-button-input" type="submit" aria-labelledby="auth-signin-button-announce"><span id="auth-signin-button-announce" class="a-button-text" aria-hidden="true">
      ログイン
      </span></span></span>
   </div>
</div>

```